### PR TITLE
Test startOfDay function when current time is before dayStart

### DIFF
--- a/test/common/libs/cron.test.js
+++ b/test/common/libs/cron.test.js
@@ -132,6 +132,18 @@ describe('cron utility functions', () => {
 
       expect(result).to.be.sameMoment(localMoment('2020-02-01', -offset));
     });
+
+    it('calculates the start of the previous day when current time is before dayStart in user timezone', () => {
+      const options = {
+        now: moment('2023-06-15T02:30:00.000Z'),
+        dayStart: 4,
+        timezoneOffset: 240
+      };
+
+      const result = startOfDay(options);
+
+      expect(result).to.be.sameMoment('2023-06-14T04:00:00.000-04:00');
+    });
   });
 
   describe('daysSince', () => {


### PR DESCRIPTION
The startOfDay function calculates the start of the day based on the provided options, including the current time (now), dayStart hour, and timezone offset.

This new test case focuses on the scenario where the current time is before the configured dayStart hour in the user's timezone. It ensures that the function correctly calculates the start of the previous day in such cases.

The test sets up the options with a specific current time (2023-06-15T02:30:00.000Z), dayStart hour (4), and timezone offset (240 minutes). It then calls the startOfDay function with these options and verifies that the returned moment object represents the expected start of the previous day (2023-06-14T04:00:00.000-04:00).

This test is important to ensure the correctness and reliability of the startOfDay function, especially when dealing with different timezones and edge cases where the current time is before the configured dayStart hour.