### PR TITLE
Add test for getLanguageFromUser to handle null user

### DIFF
--- a/test/api/unit/libs/language.test.js
+++ b/test/api/unit/libs/language.test.js
@@ -5,12 +5,20 @@ import {
 import {
   generateReq,
 } from '../../../helpers/api-unit.helper';
+import { expect } from 'chai';
+import sinon from 'sinon';
 
 describe('language lib', () => {
   let req;
+  let getLanguageFromBrowserStub;
 
   beforeEach(() => {
     req = generateReq();
+    getLanguageFromBrowserStub = sinon.stub(, 'getLanguageFromBrowser');
+  });
+
+  afterEach(() => {
+    getLanguageFromBrowserStub.restore();
   });
 
   describe('getLanguageFromUser', () => {
@@ -32,6 +40,15 @@ describe('language lib', () => {
       };
 
       expect(getLanguageFromUser(user, req)).to.equal('en');
+    });
+
+    it('falls back to browser language if user is null', () => {
+      req.headers['accept-language'] = 'es-MX';
+      getLanguageFromBrowserStub.returns('es_419');
+      
+      expect(getLanguageFromUser(null, req)).to.equal('es_419');
+      expect(getLanguageFromBrowserStub).to.be.calledOnce;
+      expect(getLanguageFromBrowserStub).to.be.calledWith(req);
     });
   });
 


### PR DESCRIPTION
The getLanguageFromUser function is responsible for determining the language to use for a user, based on their preferences or the browser language.

This new test case verifies that when the user is null, the function correctly falls back to using the browser language by calling the getLanguageFromBrowser function with the provided request object.

It is important to test this scenario to ensure that the function handles cases where user information may not be available, and gracefully degrades to using the browser language as a fallback. This helps maintain a consistent user experience across different scenarios.