### PR TITLE
Add test for disableClasses function to handle max level exceeded case

### DIFF
--- a/test/common/ops/disableClasses.js
+++ b/test/common/ops/disableClasses.js
@@ -1,7 +1,6 @@
 import disableClasses from '../../../website/common/script/ops/disableClasses';
-import {
-  generateUser,
-} from '../../helpers/common.helper';
+import { generateUser } from '../../helpers/common.helper';
+import { MAX_LEVEL } from '../../../website/common/script/constants';
 
 describe('shared.ops.disableClasses', () => {
   let user;
@@ -30,6 +29,33 @@ describe('shared.ops.disableClasses', () => {
     expect(user.preferences.disableClasses).to.equal(true);
     expect(user.preferences.autoAllocate).to.equal(true);
     expect(user.stats.str).to.equal(34);
+    expect(user.stats.points).to.equal(0);
+  });
+
+  it('disables classes and allocates points correctly when level exceeds max', () => {
+    const maxLevelExceeded = MAX_LEVEL + 5;
+    
+    user.stats.lvl = maxLevelExceeded;
+    user.stats.str = 25;
+    user.stats.class = 'rogue';
+    user.flags.classSelected = false;
+    user.preferences.disableClasses = false;
+    user.preferences.autoAllocate = false;
+    user.stats.points = 10;
+
+    const [data] = disableClasses(user);
+    expect(data).to.eql({
+      stats: user.stats,
+      flags: user.flags,
+      preferences: user.preferences,
+    });
+
+    expect(user.stats.lvl).to.equal(maxLevelExceeded);
+    expect(user.stats.class).to.equal('warrior');
+    expect(user.stats.str).to.equal(MAX_LEVEL);
+    expect(user.flags.classSelected).to.equal(true);
+    expect(user.preferences.disableClasses).to.equal(true);
+    expect(user.preferences.autoAllocate).to.equal(true);
     expect(user.stats.points).to.equal(0);
   });
 });


### PR DESCRIPTION
The new test case addresses the scenario where the user's level exceeds the maximum allowed level (MAX_LEVEL) when the disableClasses function is called.

The test verifies that the function correctly:
1. Sets the user's class to 'warrior'
2. Sets the user's classSelected flag to true
3. Sets the user's disableClasses preference to true
4. Sets the user's autoAllocate preference to true
5. Caps the user's strength (str) stat to the maximum level
6. Sets the user's stat points to 0

This test is important to ensure that the disableClasses function properly handles edge cases and maintains the expected behavior when the user's level is higher than the maximum allowed level.